### PR TITLE
:wrench: Configure Renovate to update app version

### DIFF
--- a/charts/enoki-mastodon/Chart.yaml
+++ b/charts/enoki-mastodon/Chart.yaml
@@ -6,6 +6,7 @@ type: application
 
 version: 0.3.8
 
+# renovate: image=ghcr.io/mastodon/mastodon
 appVersion: 4.2.1
 
 dependencies:

--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -20,6 +20,7 @@ version: 4.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
+# renovate: image=ghcr.io/mastodon/mastodon
 appVersion: v4.2.1
 
 dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "(^|/)Chart\\.yaml$"
+      ],
+      "matchStrings": [
+        "#\\s?renovate: image=(?<depName>.*?)\\s?appVersion:\\s?\\\"?(?<currentValue>[\\w+\\.\\-]*)"
+      ],
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
Add a regexManager that looks for Renovate markup in the chart file and specify these markup strings to source image versions from the official image registry of the application.